### PR TITLE
removed width 22rem style to fix card size issue

### DIFF
--- a/admin-view/index.html
+++ b/admin-view/index.html
@@ -100,8 +100,17 @@
                 <br/>
 
                 <!-- All complaints -->
-                <div class="container">
+                <div class="container" id="homeContent" style="display: block">
+                    <input class="form-control" id="searchBox" placeholder="Search complaints..." style="margin: auto"/>
+                    <br/>
                     <div class="card-columns justify-content-center" id="complaintCards">
+                    </div>
+                </div>
+
+                <!-- TODO: Add list of users -->
+                <div class="container" id="userContents" style="display: none">
+                    <div class="" id="userCards">
+
                     </div>
                 </div>
             </div>
@@ -110,7 +119,7 @@
         <!-- Firebase Imports -->
         <script src="/__/firebase/7.17.1/firebase-app.js"></script>
         <script src="/__/firebase/7.17.1/firebase-auth.js"></script>
-        <script src="/__/firebase/7.17.1/firebase-analytics.js"></script>
+        <script src="/__/firebase/7.17.1/firebase-analytics.js" async></script>
         <script src="/__/firebase/7.17.1/firebase-firestore.js"></script>
         <script src="/__/firebase/7.17.1/firebase-storage.js"></script>
 

--- a/admin-view/index.js
+++ b/admin-view/index.js
@@ -83,12 +83,11 @@ function generateComplaintCard(complaint_data) {
     let card_footer_div = document.createElement("div");
 
     // Set attributes
-    column_div.setAttribute("class", "col-auto mb-3");
+    //column_div.setAttribute("class", "col-auto mb-3");
     // TODO: Create data id that identifies both the post, likely by using the timestamp and the user number
     // column_div.setAttribute("data-id", id);
 
     card_div.setAttribute("class", "card text-center");
-    card_div.setAttribute("style", "width: 22rem");
 
     card_body_div.setAttribute("class", "card-body");
     card_footer_div.setAttribute("class", "card-footer text-muted");


### PR DESCRIPTION
Closes #4 

I removed the style and class attributes to each card to fix. Due to the width of the cards being static, that caused cards to overlap on smaller devices. However, removing these make the width proportionate to the screen size. This should help with making the admin site a PWA.